### PR TITLE
allow obfuscation of channel names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ Display visualisation (after this step, you rerun generation step and just reloa
 
     cd vis && python3 -m http.server 8000 &
     open http://localhost:8000
+
+If you'd like to share the visualisation, you can just share the contents of the vis/ directory.
+
+If you want to share, but don't want to give away your channel names then try
+
+    python3 visualise.py --in content.sims.json --out vis/vis.json --obfuscate
+    
+This will replace parts of channel names with a consistent, but arbitrary, replacement
+e.g. "my-channel-name" becomes "mazut-duller-toffy".
+
+By default this will look for random replacement words in /usr/share/dict/words, but you can point it to any
+file you like
+
+    python3 visualise.py --in content.sims.json --out vis/vis.json --obfuscate --words-file your-words-file
+
+

--- a/nameremapper.py
+++ b/nameremapper.py
@@ -1,0 +1,84 @@
+import random
+import re
+
+
+class RemapperForNames():
+    def __init__(self, replacements):
+        self.replacements = replacements
+
+    def remap_name(self, name):
+        remapped = []
+        for part in re.split('(\W+)', name):
+            if part in self.replacements:
+                remapped.append(self.replacements[part])
+            else:
+                remapped.append(part)
+        return "".join(remapped)
+
+    def remap_names(self, names):
+        for name in names:
+            yield self.remap_name(name)
+
+    @classmethod
+    def words_in_names(cls, names):
+        unique_words = set()
+        for name in names:
+            unique_words |= cls.words_in_name(name)
+        return list(unique_words)
+
+    @classmethod
+    def words_in_name(cls, name):
+        return set(re.split('\W+', name))
+
+
+class NotEnoughReplacementWordsInSource(Exception):
+    def __init__(self, needed, actual):
+        self.actual = actual
+        self.needed = needed
+
+    def __str__(self):
+        return "needed: {}, actual: {}".format(self.needed, self.actual)
+
+
+def builtin_sample(population, sample_size):
+    return random.sample(population, sample_size)
+
+
+class NameRemapper():
+    def __init__(self, sample_fn, replacement_word_source):
+        self.sample_fn = sample_fn
+        self.replacement_word_source = replacement_word_source
+
+    @classmethod
+    def normalise(cls, word):
+        return word.lower().rstrip()
+
+    @classmethod
+    def from_words_file(cls, words_file):
+        word_selection = []
+        with open(words_file, 'r') as words:
+            for word in words.readlines():
+                normalised = cls.normalise(word)
+                if 5 <= len(normalised) <= 6:
+                    word_selection.append(normalised)
+        return NameRemapper(sample_fn=builtin_sample, replacement_word_source=word_selection)
+
+    def for_names(self, names):
+        replacements = self.select_random(RemapperForNames.words_in_names(names))
+        return RemapperForNames(replacements)
+
+    def select_random(self, names):
+        amount_required = len(names)
+
+        replacements = self.sample_fn(self.replacement_word_source, amount_required)
+
+        if len(replacements) < amount_required:
+            raise NotEnoughReplacementWordsInSource(amount_required, len(replacements))
+
+        replacements = sorted(replacements)
+        names = sorted(names)
+
+        replacement_map = {}
+        for (name, replacement) in zip(names, replacements):
+            replacement_map[name] = replacement
+        return replacement_map

--- a/test_nameremapper.py
+++ b/test_nameremapper.py
@@ -1,0 +1,66 @@
+from nameremapper import NameRemapper, NotEnoughReplacementWordsInSource
+import unittest
+
+
+class NameRemapperTest(unittest.TestCase):
+    @staticmethod
+    def always_same(population, sample_size):
+        return population[:sample_size]
+
+    def test_remaps_single_word(self):
+        replacements = ["melba", "peach"]
+        remapper = NameRemapper(sample_fn=NameRemapperTest.always_same, replacement_word_source=replacements)
+        input_names = ["mary"]
+        remapper_for_names = remapper.for_names(input_names)
+
+        remapped = remapper_for_names.remap_name("mary")
+
+        self.assertEqual("melba", remapped)
+
+    def test_words_in_phrase_remapped_separately_to_sorted_replacements(self):
+        presorted_replacements = \
+            ["melba", "peach", "strawberry", "vanilla"]
+        input_names = \
+            ["double-barrelled", "foop", "mary"]
+        remapper = NameRemapper(sample_fn=NameRemapperTest.always_same, replacement_word_source=presorted_replacements)
+
+        remapper_for_names = remapper.for_names(input_names)
+
+        self.assertEqual("strawberry", remapper_for_names.remap_name("foop"))
+        self.assertEqual("peach-melba", remapper_for_names.remap_name("double-barrelled"))
+        self.assertEqual("vanilla", remapper_for_names.remap_name("mary"))
+
+    def test_name_parts_mapped_to_same_replacement(self):
+        presorted_replacements = \
+            ["melba", "peach", "strawberry", "vanilla"]
+        input_names = \
+            ["double-barrelled", "double-ended", "ended-up"]
+        remapper = NameRemapper(sample_fn=NameRemapperTest.always_same, replacement_word_source=presorted_replacements)
+
+        remapper_for_names = remapper.for_names(input_names)
+
+        self.assertEqual("peach-melba", remapper_for_names.remap_name("double-barrelled"))
+        self.assertEqual("peach-strawberry", remapper_for_names.remap_name("double-ended"))
+        self.assertEqual("strawberry-vanilla", remapper_for_names.remap_name("ended-up"))
+
+    def test_throws_exception_when_more_names_than_replacements(self):
+        presorted_replacements = \
+            ["melba", "peach", "strawberry", "vanilla"]
+        input_names = \
+            ["double-barrelled", "double-ended", "ended-up", "toomany"]
+        remapper = NameRemapper(sample_fn=NameRemapperTest.always_same, replacement_word_source=presorted_replacements)
+
+        self.assertRaises(NotEnoughReplacementWordsInSource, lambda: remapper.for_names(input_names))
+
+    def test_throws_exception_when_more_name_parts_than_replacements(self):
+        presorted_replacements = \
+            ["melba", "peach", "strawberry", "vanilla"]
+        input_names = \
+            ["double-barrelled", "double-ended", "ended-up-toomany"]
+        remapper = NameRemapper(sample_fn=NameRemapperTest.always_same, replacement_word_source=presorted_replacements)
+
+        self.assertRaises(NotEnoughReplacementWordsInSource, lambda: remapper.for_names(input_names))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/visualise.py
+++ b/visualise.py
@@ -1,21 +1,40 @@
-from slacker import Slacker
-
-from optparse import OptionParser
-from itertools import groupby
+import argparse
 import json
+from itertools import groupby
+from nameremapper import NameRemapper
 
-parser = OptionParser()
-parser.add_option("-i", "--in", dest="infile", help="the name of the summary JSON file")
-parser.add_option("-o", "--out", dest="outfile", help="name of JSON file to write to")
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--in", dest="infile", help="the name of the summary JSON file")
+parser.add_argument("-o", "--out", dest="outfile", help="name of JSON file to write to")
+parser.add_argument("--obfuscate", dest="obfuscate", action='store_true',
+                    help="obfuscate the channel names (see README.md)")
+default_word_file = "/usr/share/dict/words"
+parser.add_argument("--words-file", dest="words_file", default="/usr/share/dict/words",
+                    help="file with words for use in obfuscation (\"{}\")".format(default_word_file))
 
-(options, args) = parser.parse_args()
+args = parser.parse_args()
+print("{} -> {}; obfuscate={}, words_file={}".format(args.infile, args.outfile, args.obfuscate, args.words_file))
 
-with open(options.infile, 'r') as infile:
+
+def passthrough(arg):
+    return arg
+
+
+remap_names = passthrough
+
+with open(args.infile, 'r') as infile:
     summary = json.load(infile)
-    with open(options.outfile, 'w') as outfile:
+    with open(args.outfile, 'w') as outfile:
         node_number = dict()
         nodes = list()
-        for name in summary["names"]:
+
+        if args.obfuscate:
+            remapper = NameRemapper \
+                .from_words_file(args.words_file) \
+                .for_names(summary["names"])
+            remap_names = remapper.remap_names
+
+        for name in remap_names(summary["names"]):
             node = {'name': name}
             node_number[name] = len(nodes)
             nodes.append(node)
@@ -23,7 +42,7 @@ with open(options.infile, 'r') as infile:
         links = list()
         for (distance, pairs) in summary["distances"].items():
             for pair in pairs:
-                (source, target) = pair
+                (source, target) = remap_names(pair)
                 links.append({
                     'source': node_number[source],
                     'target': node_number[target],
@@ -31,16 +50,22 @@ with open(options.infile, 'r') as infile:
                 })
 
         links_with_distance_rank = list()
+
+
         def sort_by_source(link):
             return link["source"]
+
+
         def sort_by_distance(link):
             return link["distance"]
+
+
         for k, g in groupby(sorted(links, key=sort_by_source), sort_by_source):
-            for rank, link in enumerate(sorted(g,key=sort_by_distance)):
+            for rank, link in enumerate(sorted(g, key=sort_by_distance)):
                 link["source_rank"] = rank
                 links_with_distance_rank.append(link)
 
         summary = {
             'nodes': nodes,
             'links': links_with_distance_rank}
-        json.dump(summary,outfile, sort_keys=True, indent=4, separators=(',', ': '))
+        json.dump(summary, outfile, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
see README.md for more, but in summary, this replaces parts of channel names
with a consistent, but arbitrary, replacement e.g. "my-channel-name" becomes
"mazut-duller-toffy".

as part of this:
- convert visualise.py to use argparse